### PR TITLE
fix setup.py with version and find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
-    name="django-push-notifications"
+    name="django-push-notifications",
+	version="2.0.0.1",
+	packages=find_packages(),
 )
+


### PR DESCRIPTION
The `setup.cfg` should be all that's needed for the `version` and `find_packages` to work. And it seems to be working on our Vagrant, Staging and Prod infra. However, it's hard to isolate why on Docker it was failing to install package correctly during provisioning of this statement  `pip3 install --find-links=./requirements --no-deps -r ./requirements/base.txt`

This change is naive and won't cause any harm and allows us to continue forward

After merging this branch: cut a new tar from the `master` branch:
0. remove the existing tars in `universe` requirements 
0. and put the new tar in this MR for `universe` https://gitlab.galactica/cbremb/universe/merge_requests/2942
